### PR TITLE
Restore offline outbox writes to canonical event-sourced path

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -17,7 +17,6 @@ import { Html5Qrcode } from 'html5-qrcode';
 import {
   STORE_KEYS,
   STORE_CONTACTS,
-  STORE_OUTBOX,
   STORE_INBOX,
   OUTBOX_RETRY_INTERVAL_MS,
   OUTBOX_DEFAULT_TTL_MS,
@@ -54,6 +53,7 @@ import { encryptInWorker, decryptInWorker } from './worker-client.js';
 import { appendBleMessage, formatErrorMessage, formatLocalTime, setStatus } from './ui-utils.js';
 import { resolveStartupShareTargetIntake } from './share-target-intake.js';
 import { createTransportManager } from '../../crypto/transport.js';
+import { addToOutbox } from '../../crypto/store.js';
 import { createMeshRuntime } from './runtime-mesh.js';
 import { mountOperatorPanel } from './operator-panel.js';
 import { t as tr, setLang, getLang } from './i18n.js';
@@ -943,24 +943,8 @@ window.bleSendEncrypted = async function() {
     if (bleManager.isConnected) {
       setStatus(true, 'Message sent via Bluetooth!');
     } else {
-      // Persist to IndexedDB so the entry survives a page reload.
-      // The real BLEManager also writes to its internal store; this idbPut
-      // (same msgId keyPath) is a harmless overwrite in that case, and ensures
-      // the outbox is populated even when a mock BLEManager is injected.
-      const now = Date.now();
-      await idbPut(STORE_OUTBOX, {
-        msgId: message.msgId ?? `offline-${now}`,
-        recipientFp: null,
-        message,
-        createdAt: now,
-        status: 'pending',
-        attempts: 0,
-        lastAttempt: null,
-        schemaVersion: 4,
-        priority: 1,
-        ttl: now + 7 * 24 * 60 * 60 * 1000,
-        linkId: null
-      });
+      // Route through canonical append-only outbox API to keep event-log replay authoritative.
+      await addToOutbox(message, null, { priority: 1 });
       setStatus(true, 'Bluetooth is offline. Message queued in Outbox for later delivery.');
     }
     await refreshOutboxSnapshot();

--- a/tests/integration/ble-crypto.test.js
+++ b/tests/integration/ble-crypto.test.js
@@ -23,9 +23,16 @@ function createInMemoryStore() {
   const inbox = [];
   const seen = new Set();
   const chunks = new Map();
+  const outboxAdds = [];
   return {
     inbox,
+    outboxAdds,
     async addToOutbox(message, recipientFp, meta = {}) {
+      outboxAdds.push({
+        msgId: message.msgId,
+        recipientFp,
+        status: meta.status || "pending"
+      });
       outbox.set(message.msgId, {
         msgId: message.msgId,
         message,
@@ -1192,6 +1199,10 @@ test("integration: offline send queues in outbox, then connected flush delivers 
   const queuedEntry = senderStore.snapshot().find((entry) => entry.msgId === queuedMessage.msgId);
   if (!queuedEntry) {
     throw new Error("Expected message to be queued in outbox while offline");
+  }
+  const queuedViaStoreApi = senderStore.outboxAdds.find((entry) => entry.msgId === queuedMessage.msgId);
+  if (!queuedViaStoreApi) {
+    throw new Error("Expected offline send to queue via store.addToOutbox canonical API");
   }
   if (queuedEntry.status !== "pending") {
     throw new Error(`Expected queued status=pending, got ${queuedEntry.status}`);

--- a/tests/integration/store-event-sourcing-phase3.test.js
+++ b/tests/integration/store-event-sourcing-phase3.test.js
@@ -196,6 +196,9 @@ function assert(condition, message) {
     await deleteFromInbox("i-1");
 
     const allEvents = await idbGetAll(STORE_EVENT_LOG);
+    const queuedCreateEvent = allEvents.find((event) => event.eventId === "evt-outbox-created-1");
+    assert(Boolean(queuedCreateEvent), "offline queue create must emit canonical outbox-created event");
+    assert(queuedCreateEvent.type === "outbox-created", "offline queue create event type should be outbox-created");
     assert(allEvents.some((event) => event.type === "outbox-status-updated"), "outbox status transition must be logged");
     assert(allEvents.some((event) => event.type === "outbox-removed"), "outbox removal must be logged");
     assert(allEvents.some((event) => event.type === "inbox-read"), "inbox read must be logged");
@@ -253,6 +256,19 @@ function assert(condition, message) {
     const finalOutbox = await idbGetAll(STORE_OUTBOX);
     const dupRows = finalOutbox.filter((entry) => entry.msgId === "dup-1");
     assert(dupRows.length === 1, "duplicate outbox event ingest should project exactly one row");
+
+    await addToOutbox({ msgId: "queued-persist-1", body: "ciphertext" }, "peer-d", {
+      sourceEventId: "evt-queued-persist-1"
+    });
+    const preRebuildQueued = await idbGetAll(STORE_OUTBOX);
+    assert(preRebuildQueued.some((entry) => entry.msgId === "queued-persist-1"), "queued message should exist before rebuild");
+
+    await rebuildMaterializedViewsFromEventLog();
+    const postRebuildQueued = await idbGetAll(STORE_OUTBOX);
+    assert(
+      postRebuildQueued.some((entry) => entry.msgId === "queued-persist-1" && entry.status === DELIVERY_STATUS.PENDING),
+      "queued message should survive rebuild with pending status"
+    );
 
     console.log("✓ integration: event-log replay is authoritative for outbox/inbox materialized views");
   } catch (error) {

--- a/tests/integration/store-maintenance.test.js
+++ b/tests/integration/store-maintenance.test.js
@@ -172,6 +172,7 @@ const {
 
 async function seedStaleData(now) {
   await addToOutbox({ msgId: "expired" }, "fp", { ttl: now - 1 });
+  await addToOutbox({ msgId: "valid-queued" }, "fp", { ttl: now + (90 * 24 * 60 * 60 * 1000) });
   await checkAndMarkSeen("seen-stale", "peer-1");
   await storeChunk({ msgId: "chunk-stale", seq: 0, total: 2, data: "aa" });
 }
@@ -199,7 +200,8 @@ function assert(condition, message) {
       idbGetAll(STORE_SEEN),
       idbGetAll(STORE_CHUNKS)
     ]);
-    assert(outbox.length === 0, "outbox should be empty after maintenance");
+    assert(outbox.length === 1, "maintenance should retain non-expired queued outbox entries");
+    assert(outbox[0].msgId === "valid-queued", "maintenance should preserve valid queued message");
     assert(seen.length === 0, "seen should be empty after maintenance");
     assert(chunks.length === 0, "chunks should be empty after maintenance");
     console.log("✓ integration: runMaintenance purges stale outbox/seen/chunks deterministically");


### PR DESCRIPTION
### Motivation

- Ensure offline queued messages are created through the append-only event-log model so `rebuildMaterializedViewsFromEventLog()` remains authoritative. 
- Eliminate app-level direct writes that bypass the canonical store API and risk divergence between materialized views and the event log. 
- Preserve current user-visible behavior: offline BLE send still queues messages and the UI shows the same status.

### Description

- Replaced the direct `idbPut(STORE_OUTBOX, ...)` fallback in `bleSendEncrypted()` with the canonical `addToOutbox(message, null, { priority: 1 })` call so offline queue creation goes through the event log. (`app/src/main.js`).
- Added regression assertions to `tests/integration/store-event-sourcing-phase3.test.js` to verify that an offline queue create emits a canonical `outbox-created` event and that a queued entry survives `rebuildMaterializedViewsFromEventLog()` with `pending` status.
- Updated `tests/integration/store-maintenance.test.js` to seed a non-expired queued entry and assert that maintenance preserves valid queued outbox entries while purging expired ones (adjusted TTL to avoid accidental expiry in the test).
- Extended `tests/integration/ble-crypto.test.js` in-memory store harness to record `addToOutbox` calls and assert that the BLE offline send path exercises the canonical `store.addToOutbox` API.
- Removed an unused `STORE_OUTBOX` import from the app facade to satisfy linting after the change.

### Testing

- Ran `node tests/integration/store-event-sourcing-phase3.test.js`; test passed and confirmed canonical `outbox-created` event emission and rebuild durability.
- Ran `node tests/integration/store-maintenance.test.js`; test passed and confirmed maintenance retains valid queued entries and purges expired ones.
- Ran `node tests/integration/ble-crypto.test.js`; test passed and confirmed offline BLE send queues via `addToOutbox` and flush behavior unchanged.
- Ran full `npm run test:integration`; all integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5da7e81a48328b2f1de8e8910b134)