### PR TITLE
Add `validate:full-local` script and document full local Playwright run

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Validation gate status: **passing (see commands below) ✓**
 | Integration | `npm run test:integration` |
 | Node relay appliance validation | `npm run test:relay-appliance` |
 | Local aggregate | `npm run validate` |
+| Local aggregate (real-browser included) | `npm run validate:full-local` |
 
 ```bash
 # Run everything
@@ -169,6 +170,7 @@ CI note:
 - Fast PR gate (`e2e_browser_smoke` job in CI) runs the Playwright **critical-path spec** (`main-ci-critical-path.spec.js`) — full key-gen → encrypt → decrypt → verify → compromised flow.
 - Full Playwright suite runs in `.github/workflows/e2e-real-browser.yml` (nightly, manual dispatch, and pushes to main/master).
 - `npm run validate` maps to `validate:local` (smoke E2E for faster local iteration), while CI uses `validate:ci` (adds `typecheck:runtime` + Playwright critical path gate).
+- `npm run validate:full-local` is the strict local equivalent for release rehearsal (`validate:local` + Playwright install + full Playwright run).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "validate": "npm run validate:local",
     "validate:local": "npm run gate:lint-typecheck:local && npm run gate:test:unit && npm run gate:test:integration && npm run gate:compat && npm run gate:e2e:smoke",
     "validate:ci": "npm run gate:lint-typecheck:ci && npm run gate:test:unit && npm run gate:test:integration && npm run gate:compat && npm run gate:e2e:ci-critical && npm run gate:e2e:ci-extra-browser",
+    "validate:full-local": "npm run validate:local && npm run test:e2e:install && npm run test:e2e:playwright",
     "ci": "npm run validate:ci",
     "gate:lint-typecheck:local": "npm run lint && npm run typecheck",
     "gate:lint-typecheck:ci": "npm run lint && npm run typecheck && npm run typecheck:runtime",


### PR DESCRIPTION
### Motivation
- Provide a strict local validation flow that installs Playwright and runs the full browser E2E suite for release rehearsals.

### Description
- Add `validate:full-local` npm script to `package.json` which runs the local validation plus `test:e2e:install` and the full Playwright run (`test:e2e:playwright`).
- Update `README.md` to include the new validation row in the testing table and expand the description mapping `npm run validate:full-local` as the strict local equivalent for release rehearsal.

### Testing
- Executed the local validation flows to verify the new command, specifically `npm run validate:local` and `npm run validate:full-local`, and both completed successfully in local verification runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e446737e248328bda8d92ac378e36b)