### PR TITLE
Add `validate:full-local` script and docs; simplify Husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Run lint-staged for pre-commit checks
 npm run pre-commit

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Validation gate status: **passing (see commands below) ✓**
 | Integration | `npm run test:integration` |
 | Node relay appliance validation | `npm run test:relay-appliance` |
 | Local aggregate | `npm run validate` |
+| Local aggregate (real-browser included) | `npm run validate:full-local` |
 
 ```bash
 # Run everything
@@ -161,6 +162,9 @@ npm run test:e2e:playwright
 # Full real-browser path (install + Playwright run)
 npm run test:e2e:real-browser
 
+# Local strict aggregate (validate:local + real-browser path)
+npm run validate:full-local
+
 # Node relay appliance path validation (first supported BLE peripheral endpoint)
 npm run test:relay-appliance
 ```
@@ -169,6 +173,7 @@ CI note:
 - Fast PR gate (`e2e_browser_smoke` job in CI) runs the Playwright **critical-path spec** (`main-ci-critical-path.spec.js`) — full key-gen → encrypt → decrypt → verify → compromised flow.
 - Full Playwright suite runs in `.github/workflows/e2e-real-browser.yml` (nightly, manual dispatch, and pushes to main/master).
 - `npm run validate` maps to `validate:local` (smoke E2E for faster local iteration), while CI uses `validate:ci` (adds `typecheck:runtime` + Playwright critical path gate).
+- `npm run validate:full-local` is the strict local equivalent for release rehearsal (`validate:local` + `test:e2e:real-browser`).
 
 ---
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -8,8 +8,10 @@
 1. Local gate: `npm run validate` (`validate:local` = lint + typecheck + unit + integration + compat + smoke E2E).
 2. CI gate: `npm run ci` (`validate:ci` = local gates + `typecheck:runtime` + Playwright critical path).
 3. For full browser coverage, run `npm run test:e2e:real-browser` in a Playwright-capable environment.
-4. Confirm [RELEASE_CHECKLIST.md](./RELEASE_CHECKLIST.md) items are all complete.
-5. Execute Go/No-Go meeting agenda.
+4. For strict local release rehearsal, run `npm run validate:full-local` (`validate:local` + `test:e2e:real-browser`).
+   - Requires Playwright-capable environment and browser install permissions (`npm run test:e2e:install` path).
+5. Confirm [RELEASE_CHECKLIST.md](./RELEASE_CHECKLIST.md) items are all complete.
+6. Execute Go/No-Go meeting agenda.
 
 ### Release exit criteria (must-pass)
 - Local and CI gate semantics both green (`validate:local`, `validate:ci`).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "validate": "npm run validate:local",
     "validate:local": "npm run gate:lint-typecheck:local && npm run gate:test:unit && npm run gate:test:integration && npm run gate:compat && npm run gate:e2e:smoke",
     "validate:ci": "npm run gate:lint-typecheck:ci && npm run gate:test:unit && npm run gate:test:integration && npm run gate:compat && npm run gate:e2e:ci-critical && npm run gate:e2e:ci-extra-browser",
+    "validate:full-local": "npm run validate:local && npm run test:e2e:real-browser",
     "ci": "npm run validate:ci",
     "gate:lint-typecheck:local": "npm run lint && npm run typecheck",
     "gate:lint-typecheck:ci": "npm run lint && npm run typecheck && npm run typecheck:runtime",


### PR DESCRIPTION
### Motivation
- Introduce a strict local validation flow that includes real-browser Playwright runs for release rehearsal and document its use. 
- Update onboarding and runbook docs so release operators can run the stricter local gate with required prerequisites. 
- Simplify the pre-commit hook to delegate to the existing npm script for lint-staged invocations.

### Description
- Add `validate:full-local` npm script that runs `npm run validate:local && npm run test:e2e:real-browser` in `package.json`. 
- Update `README.md` testing matrix and command snippets to include the new `npm run validate:full-local` entry and explain its mapping and purpose. 
- Update `docs/OPERATIONS_RUNBOOK.md` release flow to recommend `npm run validate:full-local` for strict local release rehearsal and note the Playwright installation requirement. 
- Simplify `.husky/pre-commit` to only run `npm run pre-commit` (remove the previous Husky bootstrap lines).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e446737e248328bda8d92ac378e36b)