### PR TITLE
docs(ai): add AI operations ruleset (AGENTS, audit, task prompts, policy CI)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,20 @@
+# Claude Code skills — lifeline-mesh
+
+Repo-specific skills for Claude Code. They are auto-discovered from `.claude/skills/`
+(no install step) and encode this project's real gates, high-risk zones, and specs so AI
+work stays safe and consistent. They complement `AGENTS.md` and `docs/ai/`.
+
+| Skill | When it triggers / what it does |
+|---|---|
+| `lm-validate` | Before a PR or when asked to test/verify — runs the smallest `package.json` gate that covers the change and reports what ran vs. was skipped. |
+| `lm-guard` | Before editing crypto/protocol/BLE/gateway/storage/security/CI — classifies the change as human-only / extra-care / low-risk and lists the invariants to protect. |
+| `lm-pr` | When opening/finalizing a PR — validates, then fills every section of the PR template incl. AI-usage, skipped-command reasons, security impact, spec-sync. |
+| `lm-spec` | At the start of any crypto/protocol/BLE/state change — maps the task to the authoritative spec and normative invariants. |
+
+## Usage
+- Invoke explicitly: `/lm-validate`, `/lm-guard`, `/lm-pr`, `/lm-spec`.
+- Or just describe the task; the `description:` in each `SKILL.md` lets Claude auto-select.
+
+## Editing
+Each skill is `.claude/skills/<name>/SKILL.md` with `name` + `description` frontmatter.
+Keep command names in sync with `package.json` and paths in sync with `AGENTS.md`.

--- a/.claude/skills/lm-guard/SKILL.md
+++ b/.claude/skills/lm-guard/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: lm-guard
+description: High-risk-area preflight for lifeline-mesh. Use BEFORE editing anything under crypto, protocol/spec, BLE, transport, gateway, relay, storage schema, security, or CI. Decides whether the change is AI-allowed or requires human sign-off, and lists the locked invariants that must not be broken.
+---
+
+# lm-guard — preflight before touching sensitive areas
+
+lifeline-mesh is E2E-encrypted, offline-first, no-server disaster mesh messaging. A wrong
+edit can silently break safety. Run this check before editing high-risk code.
+
+## 1. Classify the target path
+- **STOP — human-only (per `.github/CODEOWNERS`; AI may only draft/propose):**
+  `/crypto/**`; the `DMESH_MSG_V1` domain separator, field byte-lengths, SignBytes order,
+  canonical sign-target (`crypto/protocol-vnext.js`); `spec/PROTOCOL.md`,
+  `spec/PROTOCOL_VNEXT.md`, `spec/THREAT_MODEL.md`, `spec/STATE_MODEL.md`, `SECURITY.md`;
+  replay/TTL/dedup invariants; legacy-unsigned cutoff `2026-12-31T23:59:59Z`; the
+  verification state machine; `.github/workflows/**`, `package.json` scripts, SRI hashes,
+  dependency pins.
+  → Do NOT change on your own initiative. Open/annotate an issue, tag it high-risk, hand to
+  a human. If a test only passes by weakening a security check, STOP and report it.
+
+- **Extra care — allowed but read the spec first + expect human review:**
+  `/bluetooth/**`, `/transport/**`, `/gateway/**`, `/node-server/**`, `/sim/**`, IndexedDB
+  storage schema, disaster UX in `/app/src/**` (key gen, send/receive, offline).
+
+- **Low risk — AI may own (still verify + human-merge):**
+  docs, comments, translations, tests that tighten behavior, non-crypto tooling.
+
+## 2. Read the relevant spec first
+Use the `lm-spec` skill (or the map in `AGENTS.md` §3) to load the right spec before coding.
+
+## 3. Invariants to double-check if you proceed
+- Primitives: Ed25519 signing + X25519-XSalsa20-Poly1305; TweetNaCl only; `/crypto` stays
+  dependency-pure; keys never logged/exported/transmitted; no committed test keys.
+- Key separation (sign vs box); fresh ephemeral key per message; recipient binding in signature.
+- Wire format / field lengths / SignBytes order unchanged unless version-bumped w/ human OK.
+- Chunk reassembly: a missing chunk must not yield a valid decrypted payload.
+- Dedup: same `(node, msgId)` never re-delivered after duplicate-drop; parser never crashes.
+- BLE capability claims match `docs/BLE_SUPPORT_MATRIX.md`.
+
+## 4. Output
+State the classification (human-only / extra-care / low-risk), the spec you read, and the
+invariants relevant to this change. If human-only: stop and hand off.

--- a/.claude/skills/lm-pr/SKILL.md
+++ b/.claude/skills/lm-pr/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: lm-pr
+description: Prepare a lifeline-mesh pull request. Use when asked to open a PR, write a PR description, or finalize a change in this repo. Runs the right validation gate, then fills every section of .github/PULL_REQUEST_TEMPLATE.md — including honest disclosure of AI usage, commands run, commands skipped (with reason), impact, security impact, and spec/docs sync.
+---
+
+# lm-pr — prepare a compliant pull request
+
+Produce a PR that satisfies `AGENTS.md` §6 and the repo PR template. Keep the PR small and
+single-purpose; split if it grows.
+
+## 1. Validate first
+Run the `lm-validate` skill to execute the correct gate for what changed. Capture results.
+
+## 2. Confirm spec-sync
+If behavior described in `spec/` or a `docs/` runbook changed, update that file in the SAME
+PR. If not needed, be ready to state why.
+
+## 3. Fill the PR template
+Populate every section of `.github/PULL_REQUEST_TEMPLATE.md`:
+- **What / Why / How to test** — check the command boxes you actually ran.
+- **Required test perspectives** — TTL/expiration, replay/resend, chunk-missing robustness,
+  encrypt→send→decrypt mainline (check the ones relevant to this change).
+- **Security notes** — signature/recipient-binding unchanged or spec-updated; replay considered.
+- **AI usage** — state AI was used and which tool.
+- **Verification run** — commands actually executed + summary; **Skipped commands + reason**
+  is REQUIRED if any required command did not run (e.g. no browser/hardware).
+- **Impact & risk** — list areas touched; flag if it hits a high-risk area (→ human review
+  per CODEOWNERS).
+- **Security impact** — "no impact, because…" or "possible impact — flagged"; confirm you did
+  NOT weaken any check to pass a test.
+- **Spec / docs sync** — updated in this PR, or why not needed.
+
+## 4. Honesty
+Do not write "secure", "safe", "audited", or "fixed" without evidence. Describe the change
+and the verification performed; leave security judgments to humans and the threat model.
+
+## 5. Branch / push
+Commit with a conventional message (`feat:`/`fix:`/`docs:`/`test:`/`refactor:`/`security:`),
+push the working branch, and open the PR only when explicitly asked.

--- a/.claude/skills/lm-spec/SKILL.md
+++ b/.claude/skills/lm-spec/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: lm-spec
+description: Map a lifeline-mesh task to the specification and docs you must read before implementing. Use at the start of any crypto, protocol, signing, BLE, transport, gateway, relay, storage, or state/sync change to find the authoritative spec, normative invariants, and version rules for that area.
+---
+
+# lm-spec — route a task to the right spec
+
+Before implementing, load the authoritative spec for the area you are touching. Behavior and
+spec must not drift (`AGENTS.md` §5).
+
+## Topic → read this first
+| Topic | Read |
+|---|---|
+| crypto / signatures / keys | `spec/PROTOCOL.md`, `spec/THREAT_MODEL.md`, `/crypto/` |
+| canonical signing / envelope kinds / msgId | `spec/PROTOCOL_VNEXT.md`, `crypto/protocol-vnext.js` |
+| verification state / event ordering / sync convergence | `spec/STATE_MODEL.md` |
+| relay / gateway / simulator dedup & parser safety | `spec/PHASE5_MODEL_SPEC.md`, `docs/GATEWAY_BRIDGE_PHASE4.md`, `docs/NODE_RELAY_APPLIANCE_PATH.md` |
+| BLE capability limits | `docs/BLE_SUPPORT_MATRIX.md`, `docs/BLE_PERIPHERAL_CAPABILITY_MATRIX.md`, `docs/ADR_BLE_PERIPHERAL_PATH.md` |
+| contribution + crypto coding rules | `CONTRIBUTING.md` |
+| AI operating rules / review checklist | `AGENTS.md`, `docs/ai/OPERATIONS.md`, `docs/ai/AUDIT_RULES.md` |
+
+## Normative anchors to respect
+- Primitives locked: Ed25519 + X25519-XSalsa20-Poly1305 (TweetNaCl); change ⇒ major version.
+- Domain separator `DMESH_MSG_V1`; fixed field byte-lengths; deterministic SignBytes order.
+- Canonical sign-target = sorted-key UTF-8 JSON; `msgId = base64(sha512(canonical).slice(0,32))`.
+- Replay window 30 days; TTL/expiration semantics; unknown `kind` ignored safely.
+- Verification state machine (revoked ⇏ verified without new key material).
+- Legacy-unsigned acceptance ends at `2026-12-31T23:59:59Z`.
+
+## Output
+Name the spec files read, the normative invariants that constrain this task, and any version
+bump / backward-compat requirement the change would trigger.

--- a/.claude/skills/lm-validate/SKILL.md
+++ b/.claude/skills/lm-validate/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: lm-validate
+description: Run the correct lifeline-mesh validation gate for the current change. Use before opening a PR, or whenever asked to test/verify/validate work in this repo. Picks the right package.json script based on which files changed (crypto/spec/BLE/gateway/UI/docs) and reports exactly what ran and what was skipped.
+---
+
+# lm-validate — run the right verification gate
+
+Pick the smallest gate that fully covers what changed, run it, and report results
+honestly. Never claim "verified" for a command you did not run.
+
+## 1. Detect scope
+Run `git status --porcelain` and `git diff --name-only` to see changed paths.
+
+## 2. Choose the gate (smallest that covers the change)
+| Changed area | Command to run |
+|---|---|
+| `/crypto/**`, `spec/**`, signing/canonicalization | `npm run test:unit` **and** `npm run test:integration` |
+| `/bluetooth/**`, `/transport/**`, `/gateway/**`, `/node-server/**`, `/sim/**`, storage, `/app/src/**` | `npm run validate:local` (lint+typecheck → unit → integration → compat → e2e smoke) |
+| Broad / cross-cutting / unsure | `npm run validate:local` |
+| Lint/type/style only | `npm run lint` **and** `npm run typecheck` |
+| Docs/comments only | `npm run lint` (optional); no test gate required |
+| Security-relevant (keys, XSS, deps, SRI) | add `npm run check:security-audit` |
+
+Crypto-only quick loop: `npm run test:crypto` + `npm run test:vectors`.
+
+## 3. Run and capture
+Execute the chosen command(s). Capture pass/fail and key output.
+
+## 4. Report (honest)
+State: which commands ran + result; which required commands were **skipped and why**
+(e.g. "test:e2e skipped — no browser/hardware in sandbox"). If a security/validation
+check would have to be weakened to pass, STOP and report it — do not weaken it.
+
+## Guardrails
+- These script names are authoritative in `package.json`; if a script is missing, report
+  it rather than inventing a command.
+- Do not modify CI gates or `package.json` scripts to make validation pass.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,35 @@
+# Codex assets — lifeline-mesh
+
+Repo-specific guidance for OpenAI Codex, mirroring the Claude Code skills in
+`.claude/skills/` so both agents follow the same rules.
+
+## What Codex reads automatically
+- **`AGENTS.md`** (repo root) is Codex's native project-instructions file and is read on its
+  own — no setup. It is the primary ruleset (change-forbidden zones, verification gates,
+  spec map, PR duties).
+
+## Custom prompts (`.codex/prompts/`)
+These are reusable prompt playbooks equivalent to the Claude skills:
+
+| Prompt | Purpose |
+|---|---|
+| `lm-validate.md` | Run the correct `package.json` validation gate; report ran vs. skipped. |
+| `lm-guard.md` | Preflight before editing crypto/protocol/BLE/gateway/security/CI. |
+| `lm-pr.md` | Validate + fill the PR template (AI usage, skip reasons, security, spec-sync). |
+| `lm-spec.md` | Map a task to the authoritative spec + normative invariants. |
+
+### How to use them with Codex
+Codex loads custom slash-prompts from its prompts directory (`$CODEX_HOME/prompts`,
+default `~/.codex/prompts/`). To get `/lm-validate` etc. as slash commands:
+
+```sh
+mkdir -p ~/.codex/prompts
+cp .codex/prompts/*.md ~/.codex/prompts/
+```
+
+Then run e.g. `/lm-validate` in Codex. Alternatively, paste a prompt file's contents
+directly into the conversation. (Project-scoped auto-loading of `.codex/prompts/` is not
+guaranteed across Codex versions, so the copy step above is the reliable path; `AGENTS.md`
+is always read regardless.)
+
+Keep command names in sync with `package.json` and paths in sync with `AGENTS.md`.

--- a/.codex/prompts/lm-guard.md
+++ b/.codex/prompts/lm-guard.md
@@ -1,0 +1,24 @@
+Preflight before editing a sensitive area of lifeline-mesh (E2E-encrypted, offline-first,
+no-server disaster mesh). Classify the change and stop if it is human-only.
+
+Classify the target path:
+- HUMAN-ONLY (per `.github/CODEOWNERS`; you may only draft/propose, not change alone):
+  `/crypto/**`; `DMESH_MSG_V1` domain separator, field byte-lengths, SignBytes order,
+  canonical sign-target (`crypto/protocol-vnext.js`); `spec/PROTOCOL.md`,
+  `spec/PROTOCOL_VNEXT.md`, `spec/THREAT_MODEL.md`, `spec/STATE_MODEL.md`, `SECURITY.md`;
+  replay/TTL/dedup invariants; legacy-unsigned cutoff `2026-12-31T23:59:59Z`; verification
+  state machine; `.github/workflows/**`, `package.json` scripts, SRI hashes, dependency pins.
+  → Do not change on your own initiative. Open/annotate a high-risk issue and hand to a human.
+  Never weaken a security check to make a test pass.
+- EXTRA CARE (allowed, read spec first, expect human review): `/bluetooth/**`,
+  `/transport/**`, `/gateway/**`, `/node-server/**`, `/sim/**`, IndexedDB schema,
+  disaster UX in `/app/src/**`.
+- LOW RISK (may own, still verify): docs, comments, translations, tests that tighten
+  behavior, non-crypto tooling.
+
+Before proceeding, read the relevant spec (see `/lm-spec` or `AGENTS.md` §3) and re-check:
+key separation (sign vs box), fresh ephemeral key per message, recipient binding, unchanged
+wire format / field lengths / SignBytes order, chunk-missing safety, dedup + parser safety,
+BLE claims matching `docs/BLE_SUPPORT_MATRIX.md`, no keys logged/exported, no committed test keys.
+
+Output: classification, spec read, invariants relevant to this change. If human-only: stop.

--- a/.codex/prompts/lm-pr.md
+++ b/.codex/prompts/lm-pr.md
@@ -1,0 +1,21 @@
+Prepare a compliant lifeline-mesh pull request. Keep it small and single-purpose.
+
+1. Validate: run `/lm-validate` (correct gate for what changed); capture results.
+2. Spec-sync: if behavior in `spec/` or a `docs/` runbook changed, update it in THIS PR.
+3. Fill every section of `.github/PULL_REQUEST_TEMPLATE.md`:
+   - What / Why / How to test (check the command boxes you actually ran).
+   - Required test perspectives: TTL/expiration, replay/resend, chunk-missing robustness,
+     encrypt→send→decrypt (check those relevant).
+   - Security notes: signature/recipient-binding unchanged or spec-updated; replay considered.
+   - AI usage: state AI was used and which tool.
+   - Verification run: commands run + summary; Skipped commands + reason is REQUIRED if any
+     required command did not run.
+   - Impact & risk: areas touched; flag high-risk areas (→ human review per CODEOWNERS).
+   - Security impact: "no impact, because…" or "possible — flagged"; confirm no check was
+     weakened to pass a test.
+   - Spec / docs sync: updated here, or why not needed.
+4. Honesty: never write "secure/safe/audited/fixed" without evidence; describe change +
+   verification only.
+5. Commit with a conventional message; push the working branch; open the PR only when asked.
+
+Full rules: `AGENTS.md` §5–6, `docs/ai/OPERATIONS.md`.

--- a/.codex/prompts/lm-spec.md
+++ b/.codex/prompts/lm-spec.md
@@ -1,0 +1,24 @@
+Map a lifeline-mesh task to the spec/docs you must read before implementing. Behavior and
+spec must not drift.
+
+Topic → read first:
+- crypto / signatures / keys → `spec/PROTOCOL.md`, `spec/THREAT_MODEL.md`, `/crypto/`
+- canonical signing / envelope kinds / msgId → `spec/PROTOCOL_VNEXT.md`, `crypto/protocol-vnext.js`
+- verification state / event ordering / sync convergence → `spec/STATE_MODEL.md`
+- relay / gateway / simulator dedup & parser safety → `spec/PHASE5_MODEL_SPEC.md`,
+  `docs/GATEWAY_BRIDGE_PHASE4.md`, `docs/NODE_RELAY_APPLIANCE_PATH.md`
+- BLE capability limits → `docs/BLE_SUPPORT_MATRIX.md`,
+  `docs/BLE_PERIPHERAL_CAPABILITY_MATRIX.md`, `docs/ADR_BLE_PERIPHERAL_PATH.md`
+- contribution + crypto coding rules → `CONTRIBUTING.md`
+- AI operating rules / review checklist → `AGENTS.md`, `docs/ai/OPERATIONS.md`, `docs/ai/AUDIT_RULES.md`
+
+Normative anchors to respect:
+- Primitives locked: Ed25519 + X25519-XSalsa20-Poly1305 (TweetNaCl); change ⇒ major version.
+- Domain separator `DMESH_MSG_V1`; fixed field byte-lengths; deterministic SignBytes order.
+- Canonical sign-target = sorted-key UTF-8 JSON; `msgId = base64(sha512(canonical).slice(0,32))`.
+- Replay window 30 days; TTL/expiration; unknown `kind` ignored safely.
+- Verification state machine (revoked ⇏ verified without new key material).
+- Legacy-unsigned acceptance ends `2026-12-31T23:59:59Z`.
+
+Output: spec files read, invariants constraining the task, any version-bump / backward-compat
+requirement the change would trigger.

--- a/.codex/prompts/lm-validate.md
+++ b/.codex/prompts/lm-validate.md
@@ -1,0 +1,19 @@
+Run the correct lifeline-mesh validation gate for the current change, then report honestly.
+
+Steps:
+1. Run `git status --porcelain` and `git diff --name-only` to see what changed.
+2. Pick the smallest gate that fully covers it:
+   - `/crypto/**` or `spec/**` or signing/canonicalization → `npm run test:unit` AND `npm run test:integration`
+   - `/bluetooth/**`, `/transport/**`, `/gateway/**`, `/node-server/**`, `/sim/**`, storage, `/app/src/**`, or unsure → `npm run validate:local`
+   - lint/type/style only → `npm run lint` AND `npm run typecheck`
+   - docs/comments only → `npm run lint` (optional)
+   - security-relevant (keys, XSS, deps, SRI) → also `npm run check:security-audit`
+   - crypto-only quick loop → `npm run test:crypto` + `npm run test:vectors`
+3. Run the chosen command(s); capture pass/fail and key output.
+4. Report which commands ran + result, and which required commands were SKIPPED and why
+   (e.g. "test:e2e skipped — no browser/hardware"). Never claim verified for a command you
+   did not run. If a check would only pass by weakening a security/validation rule, STOP and
+   report it instead of weakening it.
+
+Authority: script names live in `package.json`; do not invent commands or edit CI/scripts to
+make validation pass. Full rules: `AGENTS.md` §4.

--- a/.github/ISSUE_TEMPLATE/ai-task.yml
+++ b/.github/ISSUE_TEMPLATE/ai-task.yml
@@ -1,0 +1,59 @@
+name: AI task
+description: Delegate a scoped task to an AI agent with the right guardrails
+title: "[AI task] "
+labels: ["ai-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to hand a task to an AI agent. Read `AGENTS.md` first.
+        High-risk areas (crypto/protocol/BLE/gateway/security) still require human approval.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal / acceptance criteria
+      description: What "done" looks like, and how to verify it.
+    validations:
+      required: true
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk area
+      multiple: true
+      options:
+        - docs-only
+        - tests-only
+        - app/UI (non-crypto)
+        - tooling
+        - BLE/transport (high risk)
+        - gateway/relay/simulator (high risk)
+        - crypto (human-only — AI drafts only)
+        - protocol/spec (human-only — AI drafts only)
+        - security/CI (human-only — AI drafts only)
+    validations:
+      required: true
+  - type: textarea
+    id: specs
+    attributes:
+      label: Specs/docs to read first
+      description: e.g. spec/PROTOCOL.md, spec/THREAT_MODEL.md, docs/BLE_SUPPORT_MATRIX.md
+  - type: checkboxes
+    id: gates
+    attributes:
+      label: Required verification before PR
+      options:
+        - label: "npm run test:unit"
+        - label: "npm run test:integration"
+        - label: "npm run validate:local"
+        - label: "npm run check:security-audit (if security-relevant)"
+  - type: checkboxes
+    id: guardrails
+    attributes:
+      label: Guardrails acknowledged
+      options:
+        - label: AI will not change crypto/protocol/security/CI without human approval
+          required: true
+        - label: Unrun verification commands will be listed with reasons in the PR
+          required: true
+        - label: Spec/docs will be updated in the same PR if behavior changes
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,30 @@
 ## Security notes
 - [ ] signature / recipient-binding unchanged or updated in spec
 - [ ] replay protection considered
+
+<!-- ─── AI operations (see AGENTS.md / docs/ai/OPERATIONS.md) ─── -->
+
+## AI usage
+- [ ] AI was used for this PR. Tool(s): [Claude / Copilot / Coding Agent / other]
+- [ ] No AI used.
+
+## Verification run
+Check the boxes under **How to test** above for commands you actually ran, and paste key
+output/summary here. For security-relevant changes also run:
+- [ ] `npm run check:security-audit`
+
+Skipped commands + reason (REQUIRED if any required command was not run):
+> e.g. "test:e2e skipped — no browser in sandbox"
+
+## Impact & risk
+- Areas touched: [crypto / protocol / BLE / transport / gateway / relay / storage / UI / docs / CI]
+- [ ] Touches a high-risk area (crypto/protocol/BLE/gateway/security) → human review required per CODEOWNERS.
+
+## Security impact
+- [ ] No security impact, because: [reason]
+- [ ] Possible security impact — described above and flagged for human review.
+- [ ] I did NOT weaken any security/validation check to pass a test.
+
+## Spec / docs sync
+- [ ] Behavior in `spec/` or `docs/` changed → corresponding file updated in this PR.
+- [ ] No spec/docs change needed, because: [reason]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# GitHub Copilot / Coding Agent Instructions — lifeline-mesh
+
+Read `AGENTS.md` and `docs/ai/OPERATIONS.md` for the full rules. This is the short,
+always-on version. lifeline-mesh is E2E-encrypted, offline-first, no-server disaster
+mesh messaging; unsafe changes can break disaster-time safety.
+
+## Assumptions when generating code
+- ES modules, async/await. `/crypto/**` has NO external deps except TweetNaCl — keep it pure.
+- Never implement your own crypto. Use existing helpers in `/crypto/`. Never log, export,
+  or transmit private keys. Never hardcode or commit test keys.
+- Match existing style; prefer the smallest change; no drive-by refactors.
+
+## Red lines — do NOT change without a human (per .github/CODEOWNERS)
+- `/crypto/**`, the `DMESH_MSG_V1` domain separator, field byte-lengths, SignBytes order,
+  canonical sign-target (`crypto/protocol-vnext.js`).
+- `spec/PROTOCOL.md`, `spec/PROTOCOL_VNEXT.md`, `spec/THREAT_MODEL.md`, `spec/STATE_MODEL.md`,
+  `SECURITY.md`.
+- Replay/TTL/dedup invariants, verification state transitions, legacy-unsigned cutoff
+  `2026-12-31T23:59:59Z`.
+- `.github/workflows/**`, `package.json` scripts, SRI hashes, dependency pins.
+
+Never weaken validation or a security check to make a test pass.
+
+## Extra care (read the spec first)
+BLE `/bluetooth/**` `/transport/**`, gateway `/gateway/**`, relay `/node-server/**`,
+simulator `/sim/**`, IndexedDB storage schema, disaster UX in `/app/src/**`.
+BLE capability claims must match `docs/BLE_SUPPORT_MATRIX.md`.
+
+## Before proposing a PR
+Run what you touched: `npm run test:unit`, `npm run test:integration`, or
+`npm run validate:local`; lint/type via `npm run lint` / `npm run typecheck`. State in
+the PR which commands ran and which were skipped and why. If behavior in `spec/` or
+`docs/` changed, update that file in the same PR. Do not assert "secure"/"safe" without
+evidence.

--- a/.github/workflows/ai-policy-check.yml
+++ b/.github/workflows/ai-policy-check.yml
@@ -1,0 +1,28 @@
+name: AI Policy Check
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+permissions:
+  contents: read
+jobs:
+  ai-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify AI-ops files exist (warn only)
+        run: |
+          missing=0
+          for f in AGENTS.md .github/copilot-instructions.md \
+                   docs/ai/OPERATIONS.md docs/ai/AUDIT_RULES.md docs/ai/TASK_PROMPTS.md; do
+            if [ ! -f "$f" ]; then echo "::warning::missing AI-ops file: $f"; missing=1; fi
+          done
+          [ "$missing" -eq 0 ] && echo "All AI-ops files present."
+          exit 0
+      - name: Check PR body mentions verification (warn only)
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "$BODY" | grep -Eiq 'npm run (test|validate|lint|typecheck)|Skipped commands' \
+            && echo "PR body references verification." \
+            || echo "::warning::PR body does not mention verification commands or skip reasons."
+          exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md — AI Agent Operating Rules for lifeline-mesh
+
+This file is the FIRST thing any AI agent (Claude, Copilot/Coding Agent, code-review
+AI, task-runner AI) must read before touching this repository. It is normative for AI
+work. It does not replace `CONTRIBUTING.md`, `SECURITY.md`, `CODEOWNERS`, or `spec/`;
+it sits on top of them. Where anything here appears to conflict with `CODEOWNERS`,
+`SECURITY.md`, or `spec/`, THOSE files win and you must stop and ask a human.
+
+JA: 本ファイルはAIエージェントが最初に読む運用規約です。CODEOWNERS/SECURITY/spec と矛盾した場合はそれらが優先。
+
+## 0. What this project is (why caution matters)
+End-to-end encrypted, offline-first, no-server mesh messaging for disasters. A wrong
+change to crypto, protocol, BLE, gateway, or disaster UX can silently break safety or
+disaster-time usability. Prefer the smallest correct change. When unsure, STOP and ask.
+
+## 1. Change-FORBIDDEN without explicit human sign-off
+Do NOT modify the following on your own initiative. Propose in an issue/PR and wait for
+a human (per `.github/CODEOWNERS`):
+- Cryptographic primitives or their usage: `/crypto/**` (Ed25519 / X25519-XSalsa20-Poly1305,
+  TweetNaCl). Never invent primitives; never swap libraries; never change key handling.
+- Signing/canonicalization: the `DMESH_MSG_V1` domain separator, field byte-lengths,
+  SignBytes ordering, and the canonical sign-target (`crypto/protocol-vnext.js`).
+- Protocol wire formats and versioning: `spec/PROTOCOL.md`, `spec/PROTOCOL_VNEXT.md`.
+- Security policy / threat model: `SECURITY.md`, `spec/THREAT_MODEL.md`, `spec/STATE_MODEL.md`.
+- Replay/dedup/TTL invariants, the legacy-unsigned cutoff `2026-12-31T23:59:59Z`, and the
+  verification state machine.
+- CI, release gates, security workflows, SRI hashes, dependency pins: `.github/workflows/**`,
+  `package.json` scripts, `dependabot.yml`.
+
+You must NEVER weaken a security property to make a test pass. If a test blocks you and
+the only "fix" is loosening crypto/validation, STOP and report it in the PR instead.
+
+JA: 暗号・署名・プロトコル・脅威モデル・CIは独断変更禁止。テストを通すために検証を緩めるのは禁止。
+
+## 2. High-RISK (allowed, but extra care + spec check + human review expected)
+`/bluetooth/**`, `/transport/**`, `/gateway/**`, `/node-server/**`, `/sim/**`, storage
+schema (`IndexedDB`), and disaster-facing UX in `/app/src/**` (key generation, message
+send/receive, offline paths). Read the relevant spec first (Section 3) and call out the
+risk explicitly in the PR.
+
+## 3. Read BEFORE you implement (map task → spec)
+- crypto / signatures / keys → `spec/PROTOCOL.md`, `spec/THREAT_MODEL.md`, `/crypto/`.
+- canonical signing / envelope kinds / msgId → `spec/PROTOCOL_VNEXT.md`, `crypto/protocol-vnext.js`.
+- verification state / event ordering / sync convergence → `spec/STATE_MODEL.md`.
+- relay / gateway / simulator dedup & parser safety → `spec/PHASE5_MODEL_SPEC.md`,
+  `docs/GATEWAY_BRIDGE_PHASE4.md`, `docs/NODE_RELAY_APPLIANCE_PATH.md`.
+- BLE capability limits → `docs/BLE_SUPPORT_MATRIX.md`,
+  `docs/BLE_PERIPHERAL_CAPABILITY_MATRIX.md`, `docs/ADR_BLE_PERIPHERAL_PATH.md`.
+- contribution + crypto coding rules → `CONTRIBUTING.md`.
+
+Also read `docs/ai/OPERATIONS.md` (what you may/may not own) and `docs/ai/AUDIT_RULES.md`
+(the checklist you will be reviewed against).
+
+## 4. Run BEFORE you open a PR (verification)
+Run the fullest gate the change touches; copy results into the PR body.
+- Crypto or spec touched → `npm run test:unit` (crypto + vectors) AND `npm run test:integration`.
+- Broad change → `npm run validate:local`
+  (lint+typecheck → unit → integration → compat → e2e smoke).
+- Lint/type only → `npm run lint` and `npm run typecheck`.
+- Security-relevant → also `npm run check:security-audit`.
+
+If you cannot run a required command (no browser, no hardware, sandbox limit), you MUST
+state which command was skipped and why, in the PR body. Do not claim verified when it
+was not run.
+
+JA: PR前に該当ゲートを実行し結果をPR本文へ。未実行なら「どのコマンドをなぜ実行しなかったか」を必ず明記。
+
+## 5. Spec-sync rule
+If your code change alters behavior described in `spec/` or a `docs/` runbook, you MUST
+update the corresponding spec/doc in the SAME PR (or explain why no update is needed).
+Behavior and spec must not drift.
+
+## 6. PR disclosure duties (see PR template)
+Every AI-assisted PR must state: AI was used and which tool; verification commands
+actually run (and any skipped, with reason); files/areas impacted; security impact
+(or "none, and why"); whether spec/docs were updated. Keep PRs small and single-purpose
+so humans can review the risk. Never claim something is "secure", "safe", or "fixed"
+without evidence — describe what you changed and what you verified.
+
+## 7. When to STOP and ask a human
+Any change to Section 1 areas; any security-property trade-off; any large refactor;
+any ambiguity in a spec; any test you would have to weaken. Ask in the issue/PR; do not
+proceed on assumption.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ risk explicitly in the PR.
 Also read `docs/ai/OPERATIONS.md` (what you may/may not own) and `docs/ai/AUDIT_RULES.md`
 (the checklist you will be reviewed against).
 
+Reusable skills encode this workflow: Claude Code auto-loads `.claude/skills/`
+(`lm-spec`, `lm-guard`, `lm-validate`, `lm-pr`); Codex mirrors them in `.codex/prompts/`
+(see `.codex/README.md`). Prefer `lm-spec` → `lm-guard` before coding, `lm-validate` → `lm-pr`
+before a PR.
+
 ## 4. Run BEFORE you open a PR (verification)
 Run the fullest gate the change touches; copy results into the PR body.
 - Crypto or spec touched → `npm run test:unit` (crypto + vectors) AND `npm run test:integration`.

--- a/docs/ai/AUDIT_RULES.md
+++ b/docs/ai/AUDIT_RULES.md
@@ -1,0 +1,59 @@
+# AI/Human Audit Checklist — lifeline-mesh
+
+Shared checklist for AI code-review and human review. Reviewer confirms each relevant
+item or records why it does not apply. Anything unchecked in crypto/protocol/BLE/CI
+blocks merge and needs human sign-off (per `.github/CODEOWNERS`).
+
+## Cross-cutting (every PR)
+- [ ] Scope is small and single-purpose; no unrelated drive-by changes.
+- [ ] No private keys / secrets / test keys added, logged, exported, or transmitted.
+- [ ] PR states AI usage, commands run, commands skipped (+reason), security impact.
+- [ ] Behavior change in `spec/`/`docs/` is mirrored by a spec/doc update in the same PR.
+- [ ] No security property weakened to pass a test.
+
+## crypto (`/crypto/**`)
+- [ ] No new primitive; TweetNaCl only; `/crypto` stays dependency-pure.
+- [ ] Key separation preserved (Ed25519 signing vs X25519 box); ephemeral key per message.
+- [ ] `DMESH_MSG_V1` domain separator, field byte-lengths, and SignBytes order unchanged
+      (or version-bumped with human approval).
+- [ ] New/changed crypto has test vectors (`npm run test:vectors`); `npm run test:crypto` passes.
+
+## protocol (`spec/PROTOCOL*.md`, `crypto/protocol-vnext.js`)
+- [ ] Wire format unchanged, or a version bump + backward-compat path is documented.
+- [ ] Canonical sign-target (sorted-key JSON) still deterministic; conformance vectors pass.
+- [ ] Unknown `kind` still ignored safely; msgId derivation unchanged.
+- [ ] Legacy-unsigned cutoff `2026-12-31T23:59:59Z` not silently altered.
+
+## BLE / transport (`/bluetooth/**`, `/transport/**`)
+- [ ] Capability claims match `docs/BLE_SUPPORT_MATRIX.md` / capability matrix.
+- [ ] Chunking/reassembly: a missing chunk cannot yield a valid decrypted payload.
+- [ ] TTL/priority/outbox routing semantics preserved.
+
+## storage (`IndexedDB` schema, migrations)
+- [ ] Schema version bumped for shape changes; migration is reversible/tested.
+- [ ] Append-only event log stays source of truth; views remain rebuildable.
+- [ ] Replay DB / dedup window (30 days) intact.
+
+## gateway / relay / simulator (`/gateway/**`, `/node-server/**`, `/sim/**`)
+- [ ] Dedup invariant holds: same `(node, msgId)` never re-delivered after duplicate-drop.
+- [ ] Malformed input is rejected, never crashes the process (parser safety).
+- [ ] Deterministic simulation: same seed → identical output.
+
+## UI / disaster UX (`/app/src/**`)
+- [ ] Untrusted input rendered safely (no unsafe HTML sinks; JSON import can't inject).
+- [ ] Key gen / send / receive / offline paths still work; no silent key loss on reset.
+- [ ] Offline-first: no hard dependency on network for core flows.
+
+## docs / spec
+- [ ] Matches actual behavior; no over-claiming ("secure", "audited") without evidence.
+- [ ] Cross-links to relevant spec still valid.
+
+## tests
+- [ ] Required perspectives covered where relevant: TTL/expiration, replay/resend,
+      chunk-missing robustness, encrypt→send→decrypt mainline, key-gen E2E.
+- [ ] Tests are deterministic; flaky handling per `docs/TEST_NAMING_AND_FLAKY_POLICY.md`.
+- [ ] Tests were run; results in PR (or skip reason recorded).
+
+## CI / security config
+- [ ] No CI gate, SRI hash, or dependency pin loosened without human approval.
+- [ ] `npm audit` / CodeQL / secrets-scan expectations still met.

--- a/docs/ai/OPERATIONS.md
+++ b/docs/ai/OPERATIONS.md
@@ -1,0 +1,43 @@
+# AI Operations Policy — lifeline-mesh
+
+How to use AI (Claude, Copilot/Coding Agent, review AI, task-runner AI) safely on this
+project. Companion to `AGENTS.md` (rules), `docs/ai/AUDIT_RULES.md` (checklist),
+`docs/ai/TASK_PROMPTS.md` (templates). JA: AIの実務運用方針。
+
+## AI MAY own (low risk, still verified + human-merged)
+- Docs/comments/typos, translations, doc-example fixes.
+- Adding tests that tighten existing behavior (no production-code change).
+- Non-crypto, non-protocol bug fixes in `/app/src/**` UI, tooling in `/tools/**`.
+- Lint/type/style cleanups that don't alter behavior.
+- Drafting issues, PR descriptions, changelog entries, repro steps.
+
+## AI MUST NOT own (do not let AI decide these alone)
+- Designing or changing crypto, key handling, signing, or canonicalization.
+- Changing protocol wire format, versioning, or the legacy-unsigned cutoff.
+- Editing `SECURITY.md` / `spec/THREAT_MODEL.md` security claims, or the state machine.
+- Relaxing replay/TTL/dedup/validation invariants.
+- Changing CI gates, release criteria, security workflows, SRI, or dependency pins.
+- Any change whose only justification is "to make the failing test pass" by weakening a check.
+
+## Requires HUMAN APPROVAL before merge (AI may draft, human decides)
+- Anything under `/crypto/**`, `spec/**`, `SECURITY.md` (already enforced by CODEOWNERS).
+- BLE / transport / gateway / relay / simulator behavior changes.
+- Storage schema / migration changes.
+- Disaster-facing UX flows (key gen, send/receive, offline).
+- Dependency additions/upgrades.
+
+## Escalation
+If a task drifts into a "MUST NOT own" area, STOP: open/annotate an issue describing the
+needed change, tag it high-risk, and hand off to a human maintainer. Never proceed on
+assumption in a security-sensitive area. State assumptions explicitly in the PR/issue.
+
+## Verification expectation
+Every AI change is verified with the relevant `package.json` gate (`npm run test:unit`,
+`npm run test:integration`, `npm run validate:local`, `npm run lint`, `npm run typecheck`,
+`npm run check:security-audit`) and the results — including any skipped command and the
+reason — recorded in the PR. Unverified ≠ done.
+
+## Honesty rule
+AI output must not claim code is secure, safe, audited, or fixed without evidence.
+Describe the change and the verification performed; leave security judgments to humans
+and the threat model.

--- a/docs/ai/TASK_PROMPTS.md
+++ b/docs/ai/TASK_PROMPTS.md
@@ -1,0 +1,40 @@
+# Reusable AI Task Prompt Templates — lifeline-mesh
+
+Paste a template, fill the brackets. Every template inherits the rules in `AGENTS.md`.
+Always end by running the relevant `package.json` gate and reporting results (including
+skipped commands + reason). JA: 実務で再利用するAI依頼テンプレート。
+
+## Preamble (prepend to any task)
+> You are working on lifeline-mesh (E2E-encrypted, offline-first, no-server disaster mesh).
+> Follow `AGENTS.md`. Do NOT change `/crypto/**`, `spec/**`, `SECURITY.md`, CI, SRI, or
+> dependency pins without explicit human approval. Never weaken a security check to pass
+> a test. Keep the change small. If it drifts into a high-risk area, STOP and ask.
+
+## Bug fix
+> Fix [bug] in [file/area]. Reproduce first; explain root cause. Stay out of crypto/
+> protocol/CI unless approved. Add/adjust a regression test. Run `npm run test:unit` and
+> `npm run test:integration` (or `npm run validate:local` if broad). Report results and
+> any skipped command with reason. Update spec/docs if behavior changed.
+
+## Add tests
+> Add tests for [behavior] without changing production code. Cover edge cases:
+> [TTL/replay/chunk-missing/…]. Keep deterministic. Run the suite and paste output.
+
+## Docs update
+> Update [doc] to match current behavior of [feature]. No code change. Do not over-claim
+> security. Keep cross-links to `spec/` valid.
+
+## Security review (READ-ONLY by default)
+> Review [area] against `spec/THREAT_MODEL.md` and `docs/ai/AUDIT_RULES.md`. List concrete
+> risks with file:line and severity. Propose fixes but DO NOT change crypto/security code —
+> hand findings to a human. Do not assert the code is "secure"; describe evidence only.
+
+## Refactor
+> Refactor [target] for readability WITHOUT behavior change. No crypto/protocol/wire-format
+> change. Prove equivalence by running `npm run validate:local`. Small, single-purpose PR.
+> Split into multiple PRs if it grows.
+
+## PR review
+> Review this PR using `docs/ai/AUDIT_RULES.md`. Check scope, secrets/keys, spec-sync,
+> verification evidence, and whether any security property was weakened. Flag high-risk
+> areas for required human review. Post concise, actionable comments only.


### PR DESCRIPTION
Introduce AI-facing operating rules so AI agents, Copilot/Coding Agent,
code-review AI, and task-runner AI can work safely and consistently on
this E2E-encrypted, offline-first disaster mesh project.

- AGENTS.md: repo-wide AI rules — change-forbidden crypto/protocol/security
  zones, high-risk areas, pre-work spec map, pre-PR verification commands,
  spec-sync rule, PR disclosure duties.
- .github/copilot-instructions.md: condensed always-on Copilot ruleset.
- docs/ai/OPERATIONS.md: what AI may/may not own and human-approval gates.
- docs/ai/AUDIT_RULES.md: per-domain review checklist (crypto/protocol/BLE/
  storage/UI/docs/tests/CI).
- docs/ai/TASK_PROMPTS.md: reusable task prompt templates.
- .github/PULL_REQUEST_TEMPLATE.md: append AI-usage, verification (with
  required skip reason), impact/risk, security-impact, spec-sync blocks.
- .github/ISSUE_TEMPLATE/ai-task.yml: structured AI-task intake form.
- .github/workflows/ai-policy-check.yml: non-blocking existence/PR check.

Docs point to existing CODEOWNERS/SECURITY/spec as sources of truth and
reference package.json script names verbatim; no code, spec, or CI-gate
behavior is changed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HMuW5fKzNJitw7zTWUDMzE